### PR TITLE
Add required field for triggering github user

### DIFF
--- a/.github/workflows/syschange.yaml
+++ b/.github/workflows/syschange.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - name: Create Informational Syschange
       id: syschange
-      uses: brownuniversity/create-informational-syschange@main
+      uses: brownuniversity/create-informational-syschange@feature/include-triggering-user
       with:
         summary: "Test Ticket"
         description: "Testing Create Pull Request Github Action"

--- a/.github/workflows/syschange.yaml
+++ b/.github/workflows/syschange.yaml
@@ -11,6 +11,7 @@ jobs:
       with:
         summary: "Test Ticket"
         description: "Testing Create Pull Request Github Action"
+        author: ${{ github.event.sender.login }}
         apiKey: ${{ secrets.WS_ATLASSIAN_KEY }}
     - name: Print Ticket Link
       run: |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Creates an informational syschange via Jira Service Management.
 
 ```yaml
 - name: Create Informational Syschange
-  uses: brownuniversity/create-informational-syschange@v1
+  uses: brownuniversity/create-informational-syschange@v2
 ```
 
 See [syschange.yaml](.github/workflows/syschange.yaml) for an example, and use the [Actions tab](https://github.com/BrownUniversity/create-informational-syschange/actions/workflows/syschange.yaml) to run it.
@@ -17,6 +17,7 @@ See [syschange.yaml](.github/workflows/syschange.yaml) for an example, and use t
 
 - `summary`: Summary of change
 - `apiKey`: Atlassian API key
+- `author`: GitHub username of triggering user
 
 #### Optional
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   apiKey:
     description: 'Atlassian API Key'
     required: true
+  author:
+    description: 'GitHub username of triggering user'
+    required: true
   description:
     description: 'Description of change'
     required: false
@@ -36,6 +39,7 @@ runs:
       env:
         ISSUE_TYPE_ID: '10014' # [System] Informational Change 
         RESPONSIBLE_GROUP: 'customfield_10058'
+        GITHUB_ID: 'customfield_10392'
         PLANNED_START: 'customfield_10107'
         PLANNED_END: 'customfield_10049'
         REQUEST_TYPE: 'customfield_10010'
@@ -54,6 +58,7 @@ runs:
             "${{ env.RESPONSIBLE_GROUP }}": {
               "name": "${{ inputs.group }}"
             },
+            "${{ env.GITHUB_ID }}": "${{ inputs.author }}",
             "${{ env.PLANNED_START }}": "${{ env.NOW }}",
             "${{ env.PLANNED_END }}": "${{ env.NOW }}",
             "project": {


### PR DESCRIPTION
Nancy has asked that we pass the GitHub username who triggered the syschange and provided a custom field to put it in. This will require a major version bump. See https://brownincident-eeq2982.slack.com/archives/C05SZJGU7JP for the discussion that led to this.