### PR TITLE
Make affected service easier to use; fix test workflow

### DIFF
--- a/.github/workflows/syschange.yaml
+++ b/.github/workflows/syschange.yaml
@@ -7,11 +7,12 @@ jobs:
     steps:
     - name: Create Informational Syschange
       id: syschange
-      uses: brownuniversity/create-informational-syschange@feature/include-triggering-user
+      uses: brownuniversity/create-informational-syschange@main
       with:
         summary: "Test Ticket"
         description: "Testing Create Pull Request Github Action"
         author: ${{ github.event.sender.login }}
+        affectedService: 1631557
         apiKey: ${{ secrets.WS_ATLASSIAN_KEY }}
     - name: Print Ticket Link
       run: |

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ See [syschange.yaml](.github/workflows/syschange.yaml) for an example, and use t
 #### Required
 
 - `summary`: Summary of change
-- `apiKey`: Atlassian API key
 - `author`: GitHub username of triggering user
-- `affectedService`: Atlassian ID of the affected service
+- `affectedService`: Atlassian ID of the affected service (see below)
+- `apiKey`: Atlassian API key
 
 #### Optional
 
@@ -29,3 +29,11 @@ See [syschange.yaml](.github/workflows/syschange.yaml) for an example, and use t
 ### Outputs
 
 - `ticket-link`: Link to ticket in Jira Service Management
+
+### Required Data
+
+To find the Atlassian ID of the affected service (we'll use ASK as an example):
+
+1. Navigate to the JSM application object collection: https://brown.atlassian.net/jira/servicedesk/assets/object-schema/3?typeId=25
+2. Locate your service: https://brown.atlassian.net/jira/servicedesk/assets/object-schema/3?typeId=25&objectId=509576
+3. Grab the `objectId` from URL: `509576`

--- a/action.yml
+++ b/action.yml
@@ -4,14 +4,14 @@ inputs:
   summary:
     description: 'Summary of change'
     required: true
-  apiKey:
-    description: 'Atlassian API Key'
-    required: true
   author:
     description: 'GitHub username of triggering user'
     required: true
   affectedService:
     description: 'Atlassian ID for the affected service'
+    required: true
+  apiKey:
+    description: 'Atlassian API Key'
     required: true
   description:
     description: 'Description of change'
@@ -48,6 +48,7 @@ runs:
         REQUEST_TYPE: 'customfield_10010'
         AFFECTED_SERVICE: 'customfield_10171'
         INFORMATIONAL_SYSTEM_CHANGE: '74'
+        WORKSPACE_ID: '3015eb17-fcd8-4eb8-b534-dfbce48cd828'
       shell: bash
       run: |
         RESPONSE=$(curl --header 'Content-Type: application/json' \
@@ -63,7 +64,7 @@ runs:
               "name": "${{ inputs.group }}"
             },
             "${{ env.AFFECTED_SERVICE }}": {
-              "id": "${{ inputs.affectedService }}"
+              "id": "${{ env.WORKSPACE_ID }}:${{ inputs.affectedService }}"
             },
             "${{ env.GITHUB_ID }}": "${{ inputs.author }}",
             "${{ env.PLANNED_START }}": "${{ env.NOW }}",


### PR DESCRIPTION
All services have a `globalId` of the format `<workspaceId>:<objectId>`. This PR hardcodes the `workspaceId` so consumers only need to look up the `objectId` to use this action.
