### PR TITLE
Support affected integrations

### DIFF
--- a/.github/workflows/syschange.yaml
+++ b/.github/workflows/syschange.yaml
@@ -15,6 +15,7 @@ jobs:
           author: ${{ github.event.sender.login }}
           group: "OIT-JSM-Web Services"
           affectedServices: 1631557
+          affectedIntegrations: 2344418
           apiKey: ${{ secrets.WS_ATLASSIAN_KEY }}
       - name: Print Ticket Link
         run: |

--- a/.github/workflows/syschange.yaml
+++ b/.github/workflows/syschange.yaml
@@ -5,17 +5,18 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - name: Create Informational Syschange
-      id: syschange
-      uses: brownuniversity/create-informational-syschange@main
-      with:
-        summary: "Test Ticket"
-        description: "Testing Create Pull Request Github Action"
-        author: ${{ github.event.sender.login }}
-        group: "OIT-JSM-Web Services"
-        affectedServices: 1631557
-        apiKey: ${{ secrets.WS_ATLASSIAN_KEY }}
-    - name: Print Ticket Link
-      run: |
-        echo '::echo::on'
-        echo "${{ steps.syschange.outputs.ticket-link }}"
+      - uses: actions/checkout@v4
+      - name: Create Informational Syschange
+        id: syschange
+        uses: ./
+        with:
+          summary: "Test Ticket"
+          description: "Testing Create Pull Request Github Action"
+          author: ${{ github.event.sender.login }}
+          group: "OIT-JSM-Web Services"
+          affectedServices: 1631557
+          apiKey: ${{ secrets.WS_ATLASSIAN_KEY }}
+      - name: Print Ticket Link
+        run: |
+          echo '::echo::on'
+          echo "${{ steps.syschange.outputs.ticket-link }}"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See [syschange.yaml](.github/workflows/syschange.yaml) for an example, and use t
 
 - `description`: Longer description of change
 - `installer`: Installer Atlassian ID (defaults to EAS service account)
+- `affectedIntegrations`: Comma-separated Atlassian IDs of the affected integrations (see below)
 
 ### Outputs
 
@@ -37,3 +38,9 @@ To find the Atlassian ID of an affected service (we'll use ASK as an example):
 1. Navigate to the JSM application object collection: https://brown.atlassian.net/jira/servicedesk/assets/object-schema/3?typeId=25
 2. Locate your service: https://brown.atlassian.net/jira/servicedesk/assets/object-schema/3?typeId=25&objectId=509576
 3. Grab the `objectId` from URL: `509576`
+
+To find the Atlassian ID of an affected integration (we'll use banner-sapi as an example):
+
+1. Navigate to the JSM application object collection: https://brown.atlassian.net/jira/servicedesk/assets/object-schema/14?typeId=215
+2. Locate your integration: https://brown.atlassian.net/jira/servicedesk/assets/object-schema/14?typeId=215&objectId=2344418
+3. Grab the `objectId` from URL: `2344418`

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     description: "Syschange installer Atlassian ID"
     required: false
     default: '712020:db823f4a-761e-42b7-aff2-bcd0a391c480'
+  affectedIntegrations:
+    description: 'Comma-separated list of Atlassian IDs for the affected integrations'
+    required: false
 outputs:
   ticket-link:
     description: 'URL of created Informational Syschange'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2779,6 +2779,7 @@ const customFields = {
     REQUEST_TYPE: "customfield_10010",
     RESPONSIBLE_GROUP: "customfield_10058",
     AFFECTED_SERVICES: "customfield_10171",
+    AFFECTED_INTEGRATIONS: "customfield_10406",
     GITHUB_ID: "customfield_10392",
     PLANNED_START: "customfield_10107",
     PLANNED_END: "customfield_10049",
@@ -2790,12 +2791,17 @@ async function run() {
             author: core.getInput("author", { required: true }),
             group: core.getInput("group", { required: true }),
             affectedServices: core.getInput("affectedServices", { required: true }),
+            affectedIntegrations: core.getInput("affectedIntegrations") || "",
             apiKey: core.getInput("apiKey", { required: true }),
             description: core.getInput("description") || "",
             installer: core.getInput("installer") || jsmConstants.DEFAULT_INSTALLER,
         };
         const affectedServicesJson = inputs.affectedServices
             .split(",")
+            .map((id) => ({ id: `${jsmConstants.WORKSPACE_ID}:${id}` }));
+        const affectedIntegrationsJson = inputs.affectedIntegrations
+            .split(",")
+            .filter((x) => x)
             .map((id) => ({ id: `${jsmConstants.WORKSPACE_ID}:${id}` }));
         const now = new Date().toISOString().replace(/\.\d+/, "");
         const data = {
@@ -2813,6 +2819,10 @@ async function run() {
                 [customFields.PLANNED_END]: now,
             },
         };
+        if (affectedIntegrationsJson.length > 0) {
+            data.fields[customFields.AFFECTED_INTEGRATIONS] =
+                affectedIntegrationsJson;
+        }
         const headers = {
             authorization: `Basic ${Buffer.from(inputs.apiKey).toString("base64")}`,
         };

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ const customFields = {
   REQUEST_TYPE: "customfield_10010",
   RESPONSIBLE_GROUP: "customfield_10058",
   AFFECTED_SERVICES: "customfield_10171",
+  AFFECTED_INTEGRATIONS: "customfield_10406",
   GITHUB_ID: "customfield_10392",
   PLANNED_START: "customfield_10107",
   PLANNED_END: "customfield_10049",
@@ -24,12 +25,17 @@ export default async function run(): Promise<void> {
       author: core.getInput("author", { required: true }),
       group: core.getInput("group", { required: true }),
       affectedServices: core.getInput("affectedServices", { required: true }),
+      affectedIntegrations: core.getInput("affectedIntegrations") || "",
       apiKey: core.getInput("apiKey", { required: true }),
       description: core.getInput("description") || "",
       installer: core.getInput("installer") || jsmConstants.DEFAULT_INSTALLER,
     };
     const affectedServicesJson = inputs.affectedServices
       .split(",")
+      .map((id) => ({ id: `${jsmConstants.WORKSPACE_ID}:${id}` }));
+    const affectedIntegrationsJson = inputs.affectedIntegrations
+      .split(",")
+      .filter((x) => x)
       .map((id) => ({ id: `${jsmConstants.WORKSPACE_ID}:${id}` }));
     const now = new Date().toISOString().replace(/\.\d+/, "");
     const data = {
@@ -47,6 +53,10 @@ export default async function run(): Promise<void> {
         [customFields.PLANNED_END]: now,
       },
     };
+    if (affectedIntegrationsJson.length > 0) {
+      data.fields[customFields.AFFECTED_INTEGRATIONS] =
+        affectedIntegrationsJson;
+    }
     const headers = {
       authorization: `Basic ${Buffer.from(inputs.apiKey).toString("base64")}`,
     };


### PR DESCRIPTION
The integrations team requires support for another custom field in JIRA: affected integrations. This will be used for deploys of specific mule apps and will tie a deploy to an integration and thus to the services impacted by that integration.